### PR TITLE
Add sensor state

### DIFF
--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -22,13 +22,13 @@ void PulseMeterSensor::loop() {
 
   // Check to see if we should filter this edge out
   if (this->filter_mode_ == PULSE_METER_EDGE) {
-    if ((this->last_detected_edge_us_ - this->last_valid_edge_us_) >= this->filter_us_) {
+    if ((this->last_detected_edge_us_ - this->last_valid_high_edge_us_) >= this->filter_us_) {
       // Don't measure the first valid pulse (we need at least two pulses to measure the width)
-      if (this->last_valid_edge_us_ != 0) {
-        this->pulse_width_us_ = (this->last_detected_edge_us_ - this->last_valid_edge_us_);
+      if (this->last_valid_high_edge_us_ != 0) {
+        this->pulse_width_us_ = (this->last_detected_edge_us_ - this->last_valid_high_edge_us_);
       }
       this->total_pulses_++;
-      this->last_valid_edge_us_ = this->last_detected_edge_us_;
+      this->last_valid_high_edge_us_ = this->last_detected_edge_us_;
     }
   } else {
     // Make sure the signal has been stable long enough

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -54,8 +54,8 @@ void PulseMeterSensor::loop() {
 
   // If we've exceeded our timeout interval without receiving any pulses, assume 0 pulses/min until
   // we get at least two valid pulses.
-  const uint32_t time_since_valid_edge_us = now - this->last_valid_edge_us_;
-  if ((this->last_valid_edge_us_ != 0) && (time_since_valid_edge_us > this->timeout_us_)) {
+  const uint32_t time_since_valid_edge_us = now - this->last_valid_high_edge_us_;
+  if ((this->last_valid_high_edge_us_ != 0) && (time_since_valid_edge_us > this->timeout_us_)) {
     ESP_LOGD(TAG, "No pulse detected for %us, assuming 0 pulses/min", time_since_valid_edge_us / 1000000);
     this->last_valid_edge_us_ = 0;
     this->pulse_width_us_ = 0;

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -12,7 +12,9 @@ void PulseMeterSensor::setup() {
   this->pin_->attach_interrupt(PulseMeterSensor::gpio_intr, this, gpio::INTERRUPT_ANY_EDGE);
 
   this->last_detected_edge_us_ = 0;
-  this->last_valid_edge_us_ = 0;
+  this->last_valid_low_edge_us_ = 0;
+  this->last_valid_high_edge_us_ = 0;
+  this->sensor_is_high_ = this->isr_pin_.digital_read();
 }
 
 void PulseMeterSensor::loop() {
@@ -31,14 +33,21 @@ void PulseMeterSensor::loop() {
   } else {
     // Make sure the signal has been stable long enough
     if ((now - this->last_detected_edge_us_) >= this->filter_us_) {
-      // Only consider high pulses and "new" edges
-      if (this->isr_pin_.digital_read() && (this->last_detected_edge_us_ > this->last_valid_edge_us_)) {
+      // Only consider HIGH pulses and "new" edges if sensor state is LOW
+      if (!this->sensor_is_high_ && this->isr_pin_.digital_read() && (this->last_detected_edge_us_ != this->last_valid_high_edge_us_)) {
         // Don't measure the first valid pulse (we need at least two pulses to measure the width)
-        if (this->last_valid_edge_us_ != 0) {
-          this->pulse_width_us_ = (this->last_detected_edge_us_ - this->last_valid_edge_us_);
+        if (this->last_valid_high_edge_us_ != 0) {
+          this->pulse_width_us_ = (this->last_detected_edge_us_ - this->last_valid_high_edge_us_);
         }
+        this->sensor_is_high_ = true;
         this->total_pulses_++;
-        this->last_valid_edge_us_ = this->last_detected_edge_us_;
+        this->last_valid_high_edge_us_ = this->last_detected_edge_us_;      
+      }
+      // Only consider LOW pulses and "new" edges if sensor state is HIGH
+      else if (this->sensor_is_high_ && !this->isr_pin_.digital_read() && (this->last_detected_edge_us_ != this->last_valid_low_edge_us_))
+      {
+        this->sensor_is_high_ = false;
+        this->last_valid_low_edge_us_ = this->last_detected_edge_us_;     
       }
     }
   }

--- a/esphome/components/pulse_meter/pulse_meter_sensor.cpp
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.cpp
@@ -21,7 +21,7 @@ void PulseMeterSensor::loop() {
   const uint32_t now = micros();
 
   // Check to see if we should filter this edge out
-  if (this->filter_mode_ == PULSE_METER_EDGE) {
+  if (this->filter_mode_ == FILTER_EDGE) {
     if ((this->last_detected_edge_us_ - this->last_valid_high_edge_us_) >= this->filter_us_) {
       // Don't measure the first valid pulse (we need at least two pulses to measure the width)
       if (this->last_valid_high_edge_us_ != 0) {

--- a/esphome/components/pulse_meter/pulse_meter_sensor.h
+++ b/esphome/components/pulse_meter/pulse_meter_sensor.h
@@ -42,9 +42,11 @@ class PulseMeterSensor : public sensor::Sensor, public Component {
   Deduplicator<uint32_t> total_dedupe_;
 
   volatile uint32_t last_detected_edge_us_ = 0;
-  volatile uint32_t last_valid_edge_us_ = 0;
+  volatile uint32_t last_valid_low_edge_us_ = 0;
+  volatile uint32_t last_valid_high_edge_us_ = 0;
   volatile uint32_t pulse_width_us_ = 0;
   volatile uint32_t total_pulses_ = 0;
+  volatile bool sensor_is_high_ = false;
 };
 
 }  // namespace pulse_meter


### PR DESCRIPTION
It ignores short interrups in a pulse if after filter timout (singal is stable for a the filter period) the signal has not changed from HIGH to LOW or revise versa.

Solution for following issue: 
![image](https://user-images.githubusercontent.com/15065886/150682670-0f1341a5-296f-4056-bc01-8d7370fd5eb8.png)

Provides the fix for https://github.com/esphome/esphome/pull/3082